### PR TITLE
Add support for (common) languages, including a helper class

### DIFF
--- a/src/Language/LanguageCode.php
+++ b/src/Language/LanguageCode.php
@@ -1,0 +1,12 @@
+<?php
+namespace Packaged\Rwd\Language;
+
+interface LanguageCode
+{
+  const LANG_EN = 'en';
+  const LANG_DE = 'de';
+  const LANG_ES = 'es';
+  const LANG_FR = 'fr';
+  const LANG_IT = 'it';
+  const LANG_PT = 'pt';
+}

--- a/src/Language/LanguageHelper.php
+++ b/src/Language/LanguageHelper.php
@@ -1,0 +1,103 @@
+<?php
+namespace Packaged\Rwd\Language;
+
+class LanguageHelper
+{
+  static public function getConstants()
+  {
+    $languages = new \ReflectionClass(LanguageCode::class);
+    return $languages->getConstants();
+  }
+
+  /**
+   * @param $languageCode
+   *
+   * @return bool
+   */
+  static public function isValid($languageCode)
+  {
+    return in_array(strtolower($languageCode), self::getConstants());
+  }
+
+  /**
+   * @param $languageCode
+   *
+   * @return null|string
+   */
+  static public function getName($languageCode)
+  {
+    if($languageCode)
+    {
+      switch(strtolower($languageCode))
+      {
+        case LanguageCode::LANG_PT:
+          return 'Portuguese';
+        case LanguageCode::LANG_ES:
+          return 'Spanish';
+        case LanguageCode::LANG_IT:
+          return 'Italian';
+        case LanguageCode::LANG_FR:
+          return 'French';
+        case LanguageCode::LANG_DE:
+          return 'German';
+        case LanguageCode::LANG_EN:
+          return 'English';
+      }
+    }
+    return null;
+  }
+
+  /**
+   * @param $languageCode
+   *
+   * @return null|string
+   */
+  static public function getNativeName($languageCode)
+  {
+    if($languageCode)
+    {
+      switch(strtolower($languageCode))
+      {
+        case LanguageCode::LANG_PT:
+          return 'Português';
+        case LanguageCode::LANG_ES:
+          return 'Español';
+        case LanguageCode::LANG_IT:
+          return 'Italiano';
+        case LanguageCode::LANG_FR:
+          return 'Français';
+        case LanguageCode::LANG_DE:
+          return 'Deutsche';
+        case LanguageCode::LANG_EN:
+          return 'English';
+      }
+    }
+    return null;
+  }
+
+  /**
+   * @return array
+   */
+  static public function getKeyValues()
+  {
+    $languages = [];
+    foreach(self::getConstants() as $code)
+    {
+      $languages[$code] = self::getName($code);
+    }
+    return $languages;
+  }
+
+  /**
+   * @return array
+   */
+  static public function getNativeKeyValues()
+  {
+    $languages = [];
+    foreach(self::getConstants() as $code)
+    {
+      $languages[$code] = self::getNativeName($code);
+    }
+    return $languages;
+  }
+}

--- a/tests/Language/LanguageTest.php
+++ b/tests/Language/LanguageTest.php
@@ -1,0 +1,45 @@
+<?php
+namespace Packaged\Tests\Rwd\Language;
+
+use Packaged\Rwd\Language\LanguageCode;
+use Packaged\Rwd\Language\LanguageHelper;
+
+class LanguageTest extends \PHPUnit_Framework_TestCase
+{
+  public function testValidLanguages()
+  {
+    $languageHelper = new LanguageHelper();
+
+    // test successes
+    $testTrue = [
+      LanguageCode::LANG_EN,
+      LanguageCode::LANG_DE,
+      LanguageCode::LANG_FR,
+      LanguageCode::LANG_IT,
+      LanguageCode::LANG_ES,
+      LanguageCode::LANG_PT,
+      'PT',
+      'De',
+      'fR',
+    ];
+
+    foreach($testTrue as $item)
+    {
+      $this->assertEquals(true, $languageHelper::isValid($item));
+    }
+
+    // test fails
+    $testFalse = [
+      '',
+      ' ',
+      'test',
+      null,
+      1,
+    ];
+
+    foreach($testFalse as $item)
+    {
+      $this->assertEquals(false, $languageHelper::isValid($item));
+    }
+  }
+}


### PR DESCRIPTION
Add Language namespace.
Add LanguageHelper class containing:
- Language code isValid,
- Get native language country name (based on country code),
- Get native key value array: [$languageCode => $nativeLanguageName]
- Get English language country name (based on country code),
- Get English key value array: [$languageCode => $englishLanguageName]

Tests added