### PR TITLE
Guard string functions against null input (PHP 8.1 deprecation)

### DIFF
--- a/src/Finance/AddressVerificationService/AVSHelper.php
+++ b/src/Finance/AddressVerificationService/AVSHelper.php
@@ -16,7 +16,7 @@ class AVSHelper
 {
   public static function getAvs($code)
   {
-    $code = trim(strtoupper($code));
+    $code = trim(strtoupper((string)$code));
     switch($code)
     {
       case 'X':

--- a/src/Finance/AddressVerificationService/AVSResponse.php
+++ b/src/Finance/AddressVerificationService/AVSResponse.php
@@ -8,8 +8,8 @@ class AVSResponse implements AVSInterface
 
   public function __construct($code, $description)
   {
-    $this->_code = strtoupper($code);
-    $this->_description = trim($description);
+    $this->_code = strtoupper((string)$code);
+    $this->_description = trim((string)$description);
   }
 
   public function getCode()

--- a/src/Finance/CardVerificationValue/CVVHelper.php
+++ b/src/Finance/CardVerificationValue/CVVHelper.php
@@ -9,7 +9,7 @@ class CVVHelper
 {
   public static function getCvv($code)
   {
-    $code = trim(strtoupper($code));
+    $code = trim(strtoupper((string)$code));
     switch($code)
     {
       case 'M':

--- a/src/Finance/CardVerificationValue/CVVResponse.php
+++ b/src/Finance/CardVerificationValue/CVVResponse.php
@@ -8,8 +8,8 @@ class CVVResponse implements CVVInterface
 
   public function __construct($code, $description)
   {
-    $this->_code = strtoupper($code);
-    $this->_description = trim($description);
+    $this->_code = strtoupper((string)$code);
+    $this->_description = trim((string)$description);
   }
 
   public function getCode()

--- a/src/Language/LanguageHelper.php
+++ b/src/Language/LanguageHelper.php
@@ -72,7 +72,7 @@ class LanguageHelper
   public static function getLanguage($code, $default = null)
   {
     $code = $code ?: $default;
-    $code = str_replace(' ', '', ucwords(strtolower(str_replace('-', ' ', $code))));
+    $code = str_replace(' ', '', ucwords(strtolower(str_replace('-', ' ', (string)$code))));
     $className = sprintf('\Packaged\Rwd\Language\Languages\%sLanguage', $code);
     if(class_exists($className))
     {

--- a/src/Person/AbstractPerson.php
+++ b/src/Person/AbstractPerson.php
@@ -19,7 +19,7 @@ abstract class AbstractPerson
   {
     foreach($this->_compoundFragments as $fragment)
     {
-      if(strtolower($word) == strtolower($fragment))
+      if(strtolower((string)$word) == strtolower((string)$fragment))
       {
         return true;
       }

--- a/src/Person/Person.php
+++ b/src/Person/Person.php
@@ -69,6 +69,10 @@ class Person extends AbstractPerson
 
   private function _smartUcWords($string)
   {
+    if($string === null)
+    {
+      return '';
+    }
     // if whole string is uppercase, lowercase first
     if($string == strtoupper($string))
     {
@@ -129,7 +133,7 @@ class Person extends AbstractPerson
       $name = preg_replace('/[^a-zA-Z]/', ' ', $name);
     }
 
-    $this->_rawInput = $name;
+    $this->_rawInput = (string)$name;
     $this->_parse();
   }
 


### PR DESCRIPTION
## Summary

Fixes the PHP 8.1 deprecation warnings of the form:

```
strtoupper(): Passing null to parameter #1 ($string) of type string is deprecated
```

triggered when nullable runtime values (PSP-supplied codes, person names) reach string functions. Each affected entry point now casts to string — `(string) null === ''`, which the existing empty-code / empty-name handling already covers correctly.

## Changes

- **`Person`** — `_smartUcWords()` returns `''` on null (guards `strtoupper`/`ucwords`); constructor casts `$name` so `_rawInput` is never null (root fix; also guards `preg_split` in `_splitWords`).
- **`AbstractPerson`** — `_isCompoundFragment()` casts word/fragment before `strtolower`.
- **`CVVHelper` / `AVSHelper`** — `getCvv`/`getAvs` cast `$code` before `strtoupper`.
- **`CVVResponse` / `AVSResponse`** — constructors cast `$code`/`$description`.
- **`LanguageHelper`** — `getLanguage()` casts `$code` before the `str_replace`/`strtolower` chain.

`CountryHelper` already guarded with `is_string()`, so it was left unchanged. Build scripts under `*/build/` were skipped — dev-only tooling, not runtime paths.

## Test plan

- `vendor/bin/phpunit` — 107/107 pass (1 pre-existing risky no-assertion test, unrelated).
- `php -l` clean on all 7 changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)